### PR TITLE
Add macro for html forms

### DIFF
--- a/src/collective/z3cform/norobots/browser/configure.zcml
+++ b/src/collective/z3cform/norobots/browser/configure.zcml
@@ -5,13 +5,21 @@
 
   <!-- For the widget -->
 
-  <browser:view
+  <browser:page
       name="norobots"
       for="*"
-      permission="zope2.Public"
-      provides=".interfaces.INorobotsView"
+      permission="zope2.View"
+      allowed_interface=".interfaces.INorobotsView"
       class=".norobots.Norobots" />
   
+  <!-- html field macro -->
+  <browser:page
+        name="norobots_macro"
+        for="*"
+        template="norobots_macro.pt"
+        permission="zope2.View"
+        />
+
   <!-- Control panel -->
   
   <browser:page

--- a/src/collective/z3cform/norobots/browser/norobots_macro.pt
+++ b/src/collective/z3cform/norobots/browser/norobots_macro.pt
@@ -1,0 +1,38 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      i18n:domain="collective.z3cform.norobots">
+
+<body>
+    <tal:norobots metal:define-macro="norobots_macro"
+          i18n:domain="collective.z3cform.norobots"
+          tal:define="norobots_view nocall:context/@@norobots|nothing;
+                      question norobots_view/get_question;">
+        <label for="norobots" i18n:translate="">Are you a human ?</label>
+         <span class="fieldRequired" title="Required"
+                  i18n:domain="plone"
+                  i18n:attributes="title title_required;"
+                  i18n:translate="label_required">(Required)</span>
+        <div class="formHelp">
+          <span i18n:translate="">
+            In order to avoid spam, please answer the question below.
+          </span>
+        </div>
+        <strong><span i18n:translate="">Question</span></strong>:
+        <span i18n:translate=""
+              tal:content="python:question['title']" /><br />
+
+        <strong><span i18n:translate="">Your answer</span></strong>:
+        
+        <input type="text" 
+               id="norobots"
+               name="norobots" />
+                           
+        <input type="hidden" name="question_id" value=""
+               tal:attributes="value python:question['id']" />
+        <input type="hidden" name="id_check" value=""
+               tal:attributes="value python:question['id_check']" />
+    </tal:norobots>
+</body>
+</html>


### PR DESCRIPTION
Hi, i added a little support for html forms (without z3cform), with a simple macro.

If you think that's ok, i could update the history and maybe the readme to complete this pull request